### PR TITLE
Return validator errors in default response

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,6 +111,7 @@ const validateRequest = (req, res, next) => {
       } else {
         const err = {
           message: `Response schema validation failed for ${req.method}${req.originalUrl}`,
+          errors: validator.errors,
         };
         res.status(400);
         res.json(err);
@@ -206,6 +207,7 @@ const validateResponse = (req, res, next) => {
         } else {
           const err = {
             message: `Response schema validation failed for ${req.method}${req.originalUrl}`,
+            errors: validator.errors,
           };
           next(err);
         }


### PR DESCRIPTION
This returns the validation errors as part of the default response.

For my use-case, including the errors in the response is valuable, but I'm not sure if this would be better as a configurable option.

One alternative would be to refactor responseValidationFn ad requestValidationFn, so they could be used to modify the response.
