### PR TITLE
Gracefully handle unsupported method for path defined in schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,10 +53,12 @@ const resolveResponseModelSchema = (req, res) => {
   let schema = null;
   if (pathObj) {
     const method = req.method.toLowerCase();
-    const responseSchemas = pathObj[method].responses;
-    const code = res.statusCode || 200;
-    if (responseSchemas[code]) {
-      schema = responseSchemas[code].schema;
+    if (pathObj[method]) {
+      const responseSchemas = pathObj[method].responses;
+      const code = res.statusCode || 200;
+      if (responseSchemas[code]) {
+        schema = responseSchemas[code].schema;
+      }
     }
   }
 

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -8,7 +8,7 @@ const schema = require('./swagger-schemas/basic.json');
 
 describe('basic', () => {
   describe('validates basic response', () => {
-    it('passes response through', (done) => {
+    it('passes successful response through', (done) => {
       const router = Router();
       router.get('/status', (req, res) => {
         res.json({
@@ -23,6 +23,28 @@ describe('basic', () => {
       request(app)
         .get('/status')
         .expect(200)
+        .end((err) => {
+          if (err) throw err;
+          app.close();
+          done();
+        });
+    });
+
+    it('passes request for invalid URL through', (done) => {
+      const router = Router();
+      router.get('/status', (req, res) => {
+        res.json({
+          status: 'OK',
+        });
+      });
+      const app = createServer(router, {
+        schema,
+        validateRequest: false,
+        validateResponse: true,
+      });
+      request(app)
+        .get('/invalid')
+        .expect(404)
         .end((err) => {
           if (err) throw err;
           app.close();
@@ -98,6 +120,24 @@ describe('basic', () => {
       request(app)
         .get('/status')
         .expect(200)
+        .end((err) => {
+          if (err) throw err;
+          app.close();
+          done();
+        });
+    });
+
+    it('passes through when invalid URL', (done) => {
+      const router = Router();
+      router.get('/status', (req, res) => {
+        res.json({
+          status: 'OK',
+        });
+      });
+      const app = createServer(router, serverOpts);
+      request(app)
+        .get('/invalid')
+        .expect(404)
         .end((err) => {
           if (err) throw err;
           app.close();

--- a/test/basic.spec.js
+++ b/test/basic.spec.js
@@ -52,6 +52,28 @@ describe('basic', () => {
         });
     });
 
+    it('passes request for invalid URL through', (done) => {
+      const router = Router();
+      router.get('/status', (req, res) => {
+        res.json({
+          status: 'OK',
+        });
+      });
+      const app = createServer(router, {
+        schema,
+        validateRequest: false,
+        validateResponse: true,
+      });
+      request(app)
+        .put('/status')
+        .expect(404)
+        .end((err) => {
+          if (err) throw err;
+          app.close();
+          done();
+        });
+    });
+
     it('passes response that is not defined in the schema', (done) => {
       const router = Router();
       router.get('/route-not-in-schema', (req, res) => {
@@ -137,6 +159,24 @@ describe('basic', () => {
       const app = createServer(router, serverOpts);
       request(app)
         .get('/invalid')
+        .expect(404)
+        .end((err) => {
+          if (err) throw err;
+          app.close();
+          done();
+        });
+    });
+
+    it('passes through when valid URL invalid method', (done) => {
+      const router = Router();
+      router.get('/status', (req, res) => {
+        res.json({
+          status: 'OK',
+        });
+      });
+      const app = createServer(router, serverOpts);
+      request(app)
+        .put('/status')
         .expect(404)
         .end((err) => {
           if (err) throw err;


### PR DESCRIPTION
When you have a path defined in a schema, such as:

```yaml
/my/path:
  get:
    responses:
      200: ...etc...
```

If you issue any other request to that url except a `GET` it will fail due to `pathObj[method]` being undefined.

## The changes

There were two changes necessary to support this:

  1. A null check on `pathObj[method]`, so it gracefully aborts looking for the schema.

  2. Moving the response body processing to only occur when a schema is actually found; previously, it would incorrectly try to process the body of a request which wasn't being validated.