### PR TITLE
Support definitions from top-level of swagger schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,11 @@ const decorateWithNullable = (schema) => {
   return schema;
 };
 
+const decorateWithDefinitions = (schema) => {
+  schema.definitions = _.assign({}, options.schema.definitions || {}, schema.definitions || {});
+  return schema;
+};
+
 const resolveResponseModelSchema = (req, res) => {
   const pathObj = matchUrlWithSchema(req.originalUrl);
   let schema = null;
@@ -63,6 +68,11 @@ const resolveResponseModelSchema = (req, res) => {
   if (options.allowNullable) {
     schema = decorateWithNullable(schema);
   }
+
+  if (options.schema.definitions && schema) {
+    schema = decorateWithDefinitions(schema);
+  }
+
   return schema;
 };
 
@@ -81,6 +91,9 @@ const resolveRequestModelSchema = (req) => {
   }
   if (options.allowNullable) {
     schema = decorateWithNullable(schema);
+  }
+  if (options.schema.definitions && schema) {
+    schema = decorateWithDefinitions(schema);
   }
   return schema;
 };

--- a/test/refs.spec.js
+++ b/test/refs.spec.js
@@ -1,0 +1,55 @@
+const Router = require('express').Router;
+const request = require('supertest');
+const describe = require('mocha/lib/mocha.js').describe;
+const it = require('mocha/lib/mocha.js').it;
+const { createServer } = require('./helpers');
+
+const schema = require('./swagger-schemas/refs.json');
+
+describe('refs', () => {
+  it('validates request with schema via ref', (done) => {
+    const router = Router();
+    router.post('/person', (req, res) => {
+      res.json({
+        status: 'OK',
+      });
+    });
+    const app = createServer(router, {
+      schema,
+      validateRequest: true,
+      validateResponse: false,
+    });
+    request(app)
+      .post('/person')
+      .set({ name: 'name' })
+      .expect(200)
+      .end((err) => {
+        if (err) throw err;
+        app.close();
+        done();
+      });
+  });
+
+  it('validates response with schema via ref', (done) => {
+    const router = Router();
+    router.post('/person', (req, res) => {
+      res.json({
+        name: 'name',
+      });
+    });
+    const app = createServer(router, {
+      schema,
+      validateRequest: false,
+      validateResponse: true,
+    });
+    request(app)
+      .post('/person')
+      .set({ name: 'name' })
+      .expect(200)
+      .end((err) => {
+        if (err) throw err;
+        app.close();
+        done();
+      });
+  });
+});

--- a/test/swagger-schemas/refs.json
+++ b/test/swagger-schemas/refs.json
@@ -1,0 +1,53 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Refs example",
+    "version": "1.0.0"
+  },
+  "host": "localhost",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/person": {
+      "post": {
+        "parameters": [{
+          "in": "body",
+          "schema": { "$ref": "#/definitions/personRequest" }
+        }],
+        "responses": {
+          "200": {
+            "schema": { "$ref": "#/definitions/personResponse" }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "personRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "personResponse": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Validations currently fail when the schema of a request or response is defined as (or contains) a `$ref` to the `definitions` section of the Swagger schema.

e.g.

```yaml
paths:
  /blah:
    get:
      responses:
        200:
          schema: { $ref: "#/definitions/foo" }
definitions:
  foo:
    type: string
```

This fails with an error from `ajv` about not being able to resolve the `$ref`, because the response schema has been extracted from the whole document making `definitions` no longer addressable.

## The changes

When the schema is resolved, any `definitions` which are at the top-level of the Swagger schema are hoisted onto the local schema definition for use in validations.