### PR TITLE
fix bug, when using  $ref in schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,7 @@ const resolveResponseModelSchema = (req, res) => {
   if (options.allowNullable) {
     schema = decorateWithNullable(schema);
   }
+  schema.definitions= options.schema.definitions
   return schema;
 };
 
@@ -82,6 +83,7 @@ const resolveRequestModelSchema = (req) => {
   if (options.allowNullable) {
     schema = decorateWithNullable(schema);
   }
+  schema.definitions= options.schema.definitions
   return schema;
 };
 


### PR DESCRIPTION
when using $ref in the schema as $ref: "#/definitions/User", cause error "can't resolve reference #/definitions/User from id #"