### PR TITLE
Shouldn't mutate original data in res.end

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,10 +104,6 @@ const resolveRequestModelSchema = (req) => {
 };
 
 const sendData = (res, data, encoding) => {
-  // 'res.end' requires a Buffer or String so if it's not one, create a String
-  if (!(data instanceof Buffer) && !_.isString(data)) {
-    data = JSON.stringify(data);
-  }
   res.end(data, encoding);
 };
 
@@ -201,7 +197,7 @@ const validateResponse = (req, res, next) => {
         debug(`  Response validation errors: \n${util.inspect(validator.errors)}`);
         if (options.responseValidationFn) {
           options.responseValidationFn(req, val, validator.errors);
-          sendData(res, val, encoding);
+          sendData(res, data, encoding);
         } else {
           const err = {
             message: `Response schema validation failed for ${req.method}${req.originalUrl}`,
@@ -213,7 +209,7 @@ const validateResponse = (req, res, next) => {
         }
       } else {
         debug('Response validation success');
-        sendData(res, val, encoding);
+        sendData(res, data, encoding);
       }
     }
   };

--- a/test/pet-store.spec.js
+++ b/test/pet-store.spec.js
@@ -269,6 +269,45 @@ describe('pet store', () => {
         })
         .end(done);
     });
+
+    it('should process valid string response', (done) => {
+      const router = Router();
+      router.get('/firstname/:username', (req, res) => {
+        res.json('firstname1');
+      });
+      const app = createServer(router, optsValidateAll);
+
+      request(app)
+        .get('/firstname/user1')
+        .expect(200)
+        .end(done);
+    });
+
+    it('fails with 500 response code due to invalid response string return', (done) => {
+      const router = Router();
+      router.get('/firstname/:username', (req, res) => {
+        res.json({});
+      });
+      const app = createServer(router, optsValidateAll);
+
+      request(app)
+        .get('/firstname/user1')
+        .expect(500)
+        .end(done);
+    });
+
+    it('should process valid boolean response', (done) => {
+      const router = Router();
+      router.get('/isValidUser/:username', (req, res) => {
+        res.json(false);
+      });
+      const app = createServer(router, optsValidateAll);
+
+      request(app)
+        .get('/isValidUser/user1')
+        .expect(200)
+        .end(done);
+    });
   });
 
   describe('supports overriding ajv settings', () => {

--- a/test/swagger-schemas/pet-store.json
+++ b/test/swagger-schemas/pet-store.json
@@ -1474,6 +1474,66 @@
           }
         }
       }
+    },
+    "/firstname/{username}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Get user first name by user name",
+        "description": "",
+        "operationId": "getUserByName",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing. ",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "/isValidUser/{username}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Checks if it is a valid username",
+        "description": "",
+        "operationId": "getUserByName",
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing. ",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
     }
   },
   "securityDefinitions": {


### PR DESCRIPTION
In res.end we seem to be converting the incoming data to json to validate the request/response. However, the ideally the return from res.end should just be the original data. In all such cases, this MR just returns the original data, and removes the unnecessary conversion in stringify call in senddata. 
Have added test cases for pure string and boolean responses too. (should add for number as well).
Note: boolean and number was already working. Was just failing for string. Issue Described here: https://github.com/gargol/swagger-express-validator/issues/50